### PR TITLE
Typos in # Feature Detection and Polyfilling

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,7 +558,7 @@ To detect support for declarative Shadow DOM, something like this could be used:
 
 ```javascript
 function supportsDeclarativeShadowDOM() {
-  return HTMLTemplateElement.prototype.hasOwnProperty("shadowrootmode");
+  return HTMLTemplateElement.prototype.hasOwnProperty("shadowRootMode");
 }
 ```
 
@@ -570,7 +570,7 @@ document.querySelectorAll('template[shadowrootmode]').forEach(template => {
   const shadowRoot = template.parentNode.attachShadow({ mode });
   shadowRoot.appendChild(template.content);
   template.remove();
-}
+});
 ```
 
 # Example Custom Element


### PR DESCRIPTION
- Feature Detection:

template.hasOwnProperty('shadowRootMode') needs to be camelCase, otherwise it is not recognized in Chrome and Safari which do support the feature already. See: https://developer.chrome.com/articles/declarative-shadow-dom/

- Polyfill:

Missing ending ');'